### PR TITLE
CloudMade ends 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ If your installation is missing, feel free to add it or tell us by opening an is
 ## Submitting and querying data
 
 If you want to submit nodes to the database or if you want to query the database, please take a look at the [OpenWiFiMap API documentation](https://github.com/freifunk/openwifimap-api/blob/master/API.md).
+
+## License
+
+openwifimap-html5 is licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/script/owm_widget.js
+++ b/script/owm_widget.js
@@ -115,10 +115,10 @@ var OWMWidget = function (options, mapoptions, couchmapoptions) {
 
   widget.map = L.map(options['divId'], mapoptions);
 
-  var tile_cloudmade = L.tileLayer('http://tiles.lyrk.org/ls/{z}/{x}/{y}?apikey={key}', {
-      key: '<fillInYouApiKey>',
+  var tile_lyrk = L.tileLayer('http://tiles.lyrk.org/ls/{z}/{x}/{y}?apikey={key}', {
+      key: 'ce4ebc2a30064ca19ec3ccc898486c17',
       styleId: 997,
-      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://cloudmade.com">CloudMade</a>'
+      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://lyrk.de/">Lyrk</a>'
       }).addTo( widget.map );
   // https://raw.github.com/shramov/leaflet-plugins/master/layer/tile/Bing.js
   var tile_bing = new L.BingLayer("ArewtcSllazYp52r7tojb64N94l-OrYWuS1GjUGeTavPmJP_jde3PIdpuYm24VpR");
@@ -129,7 +129,7 @@ var OWMWidget = function (options, mapoptions, couchmapoptions) {
   widget.map.addLayer(couchlayers['nodes']).addLayer(couchlayers['links']);
   widget.control_layers = L.control.layers(
       {
-        "Cloudmade OSM": tile_cloudmade,
+        "Lyrk OSM": tile_lyrk,
         "Bing satellite": tile_bing
       },
       {

--- a/script/owm_widget.js
+++ b/script/owm_widget.js
@@ -115,8 +115,8 @@ var OWMWidget = function (options, mapoptions, couchmapoptions) {
 
   widget.map = L.map(options['divId'], mapoptions);
 
-  var tile_cloudmade = L.tileLayer('http://{s}.tile.cloudmade.com/{key}/{styleId}/256/{z}/{x}/{y}.png', {
-      key: 'e4e152a60cc5414eb81532de3d676261',
+  var tile_cloudmade = L.tileLayer('http://tiles.lyrk.org/ls/{z}/{x}/{y}?apikey={key}', {
+      key: '<fillInYouApiKey>',
       styleId: 997,
       attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://cloudmade.com">CloudMade</a>'
       }).addTo( widget.map );


### PR DESCRIPTION
Hey,

CloudMade will discontinuing their tiles for non-enterprise users in next weeks, so let's move to other tile provider. With this change we can change to [Lzrk](https://geodienste.lyrk.de/) which provides 250.000 tile views per month for free to community (non-commercial) projects.

BTW: Pushing your API-Key to github isn't the best idea. Everyone knows best practices to handle this? This project doesn't contain every build process, so i don't know how to deploy this with gh-branches. Otherwise everbody can read the api key from the production source anywhere. Mhmm.
