### PR TITLE
Readme: Update list of current deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This is a HTML5 map app with data from a [OpenWiFiMap database](http://github.co
 
 ## HTML5 app installations
 
-As currently there is no working database-backend, all maps are offline / non functional also. See https://github.com/freifunk/openwifimap-api/issues/9 for some additional details.
+Visit the main installation at [openwifimap.net](http://openwifimap.net/) or the stripped down version at [openwifimap.net/map.html](http://openwifimap.net/map.html) (e.g. for inclusion in other sites via iframe). 
+
+Of course, you can easily set up your own map! Here is a (possibly incomplete) list of installations:
+* [openwifimap.net](http://openwifimap.net/)
+* [Freifunk Berlin](http://berlin.freifunk.net/network/map/)
+* [map.weimarnetz.de](http://map.weimarnetz.de/)
+
+If your installation is missing, feel free to add it or tell us by opening an issue.
 
 ## Submitting and querying data
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,7 @@ This is a HTML5 map app with data from a [OpenWiFiMap database](http://github.co
 
 ## HTML5 app installations
 
-Visit the main installation at [openwifimap.net](http://openwifimap.net/) or the stripped down version at [openwifimap.net/map.html](http://openwifimap.net/map.html) (e.g. for inclusion in other sites via iframe). 
-
-Of course, you can easily set up your own map! Here is a (possibly incomplete) list of installations:
-* [openwifimap.net](http://openwifimap.net/)
-* [map.pberg.freifunk.net](http://map.pberg.freifunk.net/)
-* [map.weimarnetz.de](http://map.weimarnetz.de/)
-
-If your installation is missing, feel free to add it or tell us by opening an issue.
+As currently there is no working database-backend, all maps are offline / non functional also. See https://github.com/freifunk/openwifimap-api/issues/9 for some additional details.
 
 ## Submitting and querying data
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 OpenWiFiMap is a database and map for free network WiFi routers (freifunk and others, too!). 
 
-This is a HTML5 map app with data from a [OpenWiFiMap database](http://github.com/freifunk/openwifimap-api/).
+This is a HTML5 map app with data from a [OpenWiFiMap database](https://github.com/freifunk/openwifimap-api/).
 
 ## HTML5 app installations
 
-Visit the main installation at [openwifimap.net](http://openwifimap.net/) or the stripped down version at [openwifimap.net/map.html](http://openwifimap.net/map.html) (e.g. for inclusion in other sites via iframe). 
+Visit the main installation at [openwifimap.net](https://openwifimap.net/) or the stripped down version at [openwifimap.net/map.html](https://openwifimap.net/map.html) (e.g. for inclusion in other sites via iframe). 
 
 Of course, you can easily set up your own map! Here is a (possibly incomplete) list of installations:
-* [openwifimap.net](http://openwifimap.net/)
-* [Freifunk Berlin](http://berlin.freifunk.net/network/map/)
-* [map.weimarnetz.de](http://map.weimarnetz.de/)
+* [openwifimap.net](https://openwifimap.net/)
+* [Freifunk Berlin](https://berlin.freifunk.net/network/map/)
+* [map.weimarnetz.de](https://map.weimarnetz.de/)
 
 If your installation is missing, feel free to add it or tell us by opening an issue.
 
@@ -21,4 +21,4 @@ If you want to submit nodes to the database or if you want to query the database
 
 ## License
 
-openwifimap-html5 is licensed under the [MIT license](http://opensource.org/licenses/MIT).
+openwifimap-html5 is licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
~~Based on freifunk/openwifimap-api#9 the OWM-backend is down, which causes all maps to fail also.~~

~~also look at https://github.com/orgs/freifunk/projects/1~~

Meanwhile the OWM-backend is back and the maintained maps are working again. So remove the dead Freifunk-PBerg and replace by Freifunk-Berlin.

While on it replace all links in the README by their HTTPS-version.
